### PR TITLE
Fix broken handbook link anchors

### DIFF
--- a/avtaler/norge/arbeidsavtaler/ansettelse-konsernledelse.html
+++ b/avtaler/norge/arbeidsavtaler/ansettelse-konsernledelse.html
@@ -158,8 +158,8 @@
           <p>
             Hvordan Variant beregner lønn og lønnsutvikling er beskrevet i
             Håndboken,
-            <a href="https://handbook.variant.no/#lønn"
-              >https://handbook.variant.no/#lønn</a
+            <a href="https://handbook.variant.no/#Lonn"
+              >https://handbook.variant.no/#Lonn</a
             >
           </p>
         </section>
@@ -173,8 +173,8 @@
           </ul>
           <p>
             Se ellers
-            <a href="https://handbook.variant.no/#andre-goder-og-ytelser"
-              >https://handbook.variant.no/#andre-goder-og-ytelser</a
+            <a href="https://handbook.variant.no/#Goder-og-ytelser"
+              >https://handbook.variant.no/#Goder-og-ytelser</a
             >
           </p>
         </section>
@@ -213,8 +213,8 @@
 
           <p>
             Se også Håndboken for mer informasjon om permisjoner,
-            <a href="https://handbook.variant.no/#andre-goder-og-ytelser"
-              >https://handbook.variant.no/#andre-goder-og-ytelser</a
+            <a href="https://handbook.variant.no/#Goder-og-ytelser"
+              >https://handbook.variant.no/#Goder-og-ytelser</a
             >.
           </p>
         </section>
@@ -293,8 +293,8 @@
             Arbeidstaker ønsker å erverve disse rettighetene skal de forespørre
             Selskapets ledelse om dette. Se også Håndboken,
             <a
-              href="https://handbook.variant.no/#immaterielle-rettigheter-og-open-source"
-              >https://handbook.variant.no/#immaterielle-rettigheter-og-open-source</a
+              href="https://handbook.variant.no/#Rettigheter-og-open-source"
+              >https://handbook.variant.no/#Rettigheter-og-open-source</a
             >.
           </p>
 

--- a/avtaler/norge/arbeidsavtaler/ansettelse-sommerjobb.html
+++ b/avtaler/norge/arbeidsavtaler/ansettelse-sommerjobb.html
@@ -232,8 +232,8 @@
             Arbeidstaker ønsker å erverve disse rettighetene skal de forespørre
             Selskapets ledelse om dette. Se også Håndboken,
             <a
-              href="https://handbook.variant.no/#immaterielle-rettigheter-og-open-source"
-              >https://handbook.variant.no/#immaterielle-rettigheter-og-open-source</a
+              href="https://handbook.variant.no/#Rettigheter-og-open-source"
+              >https://handbook.variant.no/#Rettigheter-og-open-source</a
             >.
           </p>
         </section>

--- a/avtaler/norge/arbeidsavtaler/ansettelse.html
+++ b/avtaler/norge/arbeidsavtaler/ansettelse.html
@@ -173,8 +173,8 @@
           <p>
             Hvordan Variant beregner lønn og lønnsutvikling er beskrevet i
             Håndboken,
-            <a href="https://handbook.variant.no/#lønn"
-              >https://handbook.variant.no/#lønn</a
+            <a href="https://handbook.variant.no/#Lonn"
+              >https://handbook.variant.no/#Lonn</a
             >
           </p>
         </section>
@@ -188,8 +188,8 @@
           </ul>
           <p>
             Se ellers
-            <a href="https://handbook.variant.no/#goder-og-ytelser"
-              >https://handbook.variant.no/#goder-og-ytelser</a
+            <a href="https://handbook.variant.no/#Goder-og-ytelser"
+              >https://handbook.variant.no/#Goder-og-ytelser</a
             >
           </p>
         </section>
@@ -228,8 +228,8 @@
 
           <p>
             Se også Håndboken for mer informasjon om permisjoner,
-            <a href="https://handbook.variant.no/#goder-og-ytelser"
-              >https://handbook.variant.no/#goder-og-ytelser</a
+            <a href="https://handbook.variant.no/#Goder-og-ytelser"
+              >https://handbook.variant.no/#Goder-og-ytelser</a
             >.
           </p>
         </section>
@@ -308,8 +308,8 @@
             Arbeidstaker ønsker å erverve disse rettighetene skal de forespørre
             Selskapets ledelse om dette. Se også Håndboken,
             <a
-              href="https://handbook.variant.no/#rettigheter-og-open-source"
-              >https://handbook.variant.no/#rettigheter-og-open-source</a
+              href="https://handbook.variant.no/#Rettigheter-og-open-source"
+              >https://handbook.variant.no/#Rettigheter-og-open-source</a
             >.
           </p>
 


### PR DESCRIPTION
Several titles have been changed in the handbook, resulting in old links not pointing to specific sections.